### PR TITLE
MCP marketplace refresh: accurate copy, registry manifest, version sync

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,40 @@
+# Publishes server.json to the official MCP Registry on a version tag or GitHub Release.
+#
+# Prerequisites:
+#   - server.json in the repo root (name: io.github.foundrole/jobs-mcp-proxy).
+#   - @foundrole/ai-job-search-mcp must ALREADY be published to npm at the matching
+#     version — the registry validates the package and returns 400 "NPM package not
+#     found" until it exists. Publish to npm first (npm run publish:npm), then push
+#     the tag (or re-run this workflow).
+#   - server.json "version" and packages[0].version must equal the npm version.
+#
+# Auth: github-oidc. The registry verifies the io.github.foundrole/* namespace
+# against the repository owner via the OIDC token — no secrets needed, but the
+# workflow must run from a repo under the `foundrole` GitHub org.
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"]
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --version
+
+      - name: Publish to registry
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# MCP Registry publisher tokens (created by `mcp-publisher login`)
+.mcpregistry_github_token
+.mcpregistry_registry_token
+.mcpregistry*
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,95 +1,106 @@
-# Jobs MCP Proxy - Connect Your AI Assistant to Job Search
+# FoundRole MCP — Run Your Job Search From Your AI Assistant
 
-**Instantly add powerful job search capabilities to your AI assistant!** 🚀
+Your job search is scattered across a dozen browser tabs, a spreadsheet you forgot to update, and a calendar with no follow-up reminders. FoundRole's MCP server pulls all of it into the AI assistant you already talk to — Claude, ChatGPT, Cursor, and any other MCP client.
 
-This tool connects AI assistants like Claude, ChatGPT, and other MCP-compatible clients to comprehensive job search services. Choose from direct HTTP connection or stdio server based on your AI client.
+Ask in plain language. Your assistant searches live roles, saves the good ones to your tracker, moves them through your pipeline, and sets the follow-up reminders you'd otherwise miss — without you leaving the chat.
 
-## 🎯 For Job Seekers
+> **Connect your FoundRole account once (OAuth 2.1).** After that everything runs through conversation. Free forever — no API key to manage, no credit card.
 
-**Turn your AI assistant into a powerful job search companion** that can help you:
+## What it does for you
 
-- 🔍 Search for jobs across multiple platforms and companies
-- 📋 Get detailed job descriptions and requirements
-- 💼 Find remote, hybrid, or location-specific opportunities
-- 📊 Compare salaries and benefits
-- 🎯 Get personalized job recommendations
-- ✍️ Receive help with applications and interview prep
+- **Find roles without tab-juggling.** Search [FoundRole's live job board](https://www.foundrole.com/jobs) by title, location, company, salary, and how recently a role was posted — straight from chat.
+- **See the full picture before you apply.** Pull a job's description, requirements, salary, and apply link without opening the page.
+- **Stop losing track of applications.** Save jobs to your [Kanban application tracker](https://www.foundrole.com/job-tracker) and move them through stages (Saved → Applied → Interviewing → Offer) by asking. Attach notes, tags, expected salary, and recruiter contacts.
+- **Research before you commit.** Dig into [companies](https://www.foundrole.com/companies), [industry sectors](https://www.foundrole.com/sectors), and [hiring by location](https://www.foundrole.com/locations) to decide where to aim.
+- **Never miss a follow-up.** Set a reminder on any tracked job and get an email with a calendar (`.ics`) invite for Google Calendar, Outlook, or Apple Calendar.
+- **Let the search come to you.** Subscribe a saved search to recurring alerts (daily, weekly, or monthly) so new matches land in your inbox.
 
-## ⚡ Quick Setup (2 Options)
+It's the same account and data as [FoundRole.com](https://www.foundrole.com) — the MCP server just lets your AI drive it.
 
-### Option 1: Direct HTTP Connection (Recommended)
+> **New here?** The [FoundRole AI Search guide](https://www.foundrole.com/ai-search-mcp) walks through connecting each client step by step, with an FAQ.
 
-**For Claude Web/Desktop and ChatGPT** - Use our direct HTTP endpoint:
+## Setup
 
-**MCP Server URL:** `https://www.foundrole.com/mcp`
+Two ways to connect, depending on your client. Either way you'll authorize with your FoundRole account through a standard OAuth sign-in the first time.
 
-This is the easiest method for modern AI clients that support HTTP MCP connections.
+### Option 1 — Direct HTTP (recommended for Claude & ChatGPT)
 
-### Option 2: stdio Server (For Other Clients)
+Point your client at the FoundRole MCP endpoint:
 
-For MCP-compatible clients that require stdio transport:
+```
+https://www.foundrole.com/mcp
+```
+
+Modern clients open a browser window to sign in to FoundRole on first connect, then remember it.
+
+### Option 2 — stdio bridge (for clients without remote HTTP MCP)
+
+Run the proxy locally with npx; it bridges your client's stdio transport to the FoundRole endpoint and handles the OAuth handshake:
 
 ```bash
 npx @foundrole/ai-job-search-mcp
 ```
 
-This starts a local proxy server that communicates via standard input/output.
+## Connecting your AI assistant
 
-## 🤖 Connecting to AI Assistants
+### Claude Web/Desktop
 
-### Claude Web/Desktop Setup
+**Estimated time:** ~2 minutes
 
-**Estimated Time:** 2 minutes | **Requirements:** Claude Pro account
-
-1. Navigate to the main settings or preferences area of Claude (click your profile or settings icon)
-
-2. Find the "Connectors" or "Tools" section and click 'Add custom connector'
-
-3. In the Name or Label field, enter: `Foundrole`
-
-4. In the Remote MCP server URL field, paste the following endpoint:
+1. Open Claude settings (profile / settings icon).
+2. Find **Connectors** (or **Tools**) and click **Add custom connector**.
+3. Name it `FoundRole`.
+4. In the **Remote MCP server URL** field, paste:
 
    ```
    https://www.foundrole.com/mcp
    ```
 
-5. Save the configuration and allow Claude to connect to the Found Role server
+5. Save, then complete the FoundRole sign-in when Claude opens the authorization window.
 
-6. Once connected, you can access job search capabilities directly within your Claude conversations
+> Claude's custom connectors require a Claude Pro/Team/Enterprise plan on Claude's side. The FoundRole connection itself is free.
 
-> **🔗 Pro Account Required:** Claude MCP connectors require a Claude Pro subscription to access external data sources and tools.
+### ChatGPT
 
-### ChatGPT Setup
+**Estimated time:** ~3 minutes
 
-**Estimated Time:** 3 minutes | **Requirements:** ChatGPT Plus/Team/Enterprise
-
-1. In the ChatGPT web interface, click your profile name and select 'Settings'
-
-2. Navigate to the 'Connectors' tab within the settings menu
-
-3. Click 'Add new connector' or 'Add custom connector'
-
-4. For the 'Name' field, enter: `foundrole`
-
-5. When prompted for the server URL, paste the following endpoint:
+1. In ChatGPT, open **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Name it `FoundRole`.
+4. Paste the server URL when prompted:
 
    ```
    https://www.foundrole.com/mcp
    ```
 
-6. Follow any on-screen prompts to authorize the connection
+5. Follow the on-screen prompts to authorize, signing in to FoundRole.
+6. Select **FoundRole** as a source in Deep Research or when enabling connectors.
 
-7. Once added, you can select 'Found Role' as a data source when using Deep Research or enabling connectors
+> ChatGPT connectors require a ChatGPT Plus/Team/Enterprise plan on ChatGPT's side. The FoundRole connection itself is free.
 
-> **🔒 Premium Features:** ChatGPT connectors and Deep Research mode require ChatGPT Plus, Team, or Enterprise subscription.
+### Cursor / VS Code / Windsurf
 
-### LM Studio Setup
+Add FoundRole to your client's MCP config. With the stdio bridge:
 
-**Estimated Time:** 3 minutes | **Requirements:** Node.js + npm
+```json
+{
+  "mcpServers": {
+    "foundrole": {
+      "command": "npx",
+      "args": ["@foundrole/ai-job-search-mcp@latest"]
+    }
+  }
+}
+```
 
-1. Open LM Studio and navigate to the MCP servers configuration section
+Clients that support remote HTTP MCP can instead point directly at `https://www.foundrole.com/mcp`. Authorize with FoundRole on first use.
 
-2. Create or edit your MCP servers configuration file with the following JSON:
+### LM Studio
+
+**Estimated time:** ~3 minutes | **Requires:** Node.js + npm
+
+1. Open LM Studio's MCP servers configuration.
+2. Add this entry:
 
    ```json
    {
@@ -103,21 +114,15 @@ This starts a local proxy server that communicates via standard input/output.
    }
    ```
 
-3. Save the configuration file and restart LM Studio to load the new MCP server
+3. Save and restart LM Studio.
+4. Confirm **foundrole** appears in your MCP servers list, then authorize with FoundRole on first use.
 
-4. Verify the connection by checking that Found Role appears in your available MCP servers list
+### Perplexity Desktop
 
-5. You can now access job search capabilities through LM Studio's chat interface
+**Estimated time:** ~4 minutes | **Requires:** Perplexity Pro + Node.js
 
-> **💡 Requirements:** Make sure you have Node.js and npm installed on your system, as the MCP server runs using npx. LM Studio will automatically manage the server connection once configured.
-
-### Perplexity Desktop Setup
-
-**Estimated Time:** 4 minutes | **Requirements:** Perplexity Pro + Node.js
-
-1. Open Perplexity Desktop and navigate to MCP servers configuration
-
-2. Create or edit your MCP configuration with the following JSON:
+1. Open Perplexity's MCP configuration.
+2. Add:
 
    ```json
    {
@@ -127,65 +132,55 @@ This starts a local proxy server that communicates via standard input/output.
    }
    ```
 
-3. Save the configuration and restart Perplexity to load the MCP server
+3. Save and restart Perplexity, then authorize with FoundRole on first use.
 
-4. Verify the connection in Perplexity's MCP servers list
+> Perplexity uses stdio MCP transport — Node.js and npm must be installed.
 
-5. Access job search capabilities through Perplexity Pro features
+## Try saying
 
-> **⚠️ Note:** Perplexity uses stdio MCP transport. Make sure Node.js and npm are installed for the MCP server to run properly.
+- _"Find senior backend engineer roles in San Francisco posted this week."_
+- _"Pull the full details and apply link for that Stripe job."_
+- _"Save it to my tracker and mark it Applied."_
+- _"Add a note that I referred through Alex, and tag it fintech."_
+- _"Remind me to follow up next Tuesday morning."_
+- _"What's in my Interviewing column right now?"_
+- _"Subscribe me to weekly alerts for remote React jobs."_
 
-## 💬 Example Usage
+## Security
 
-Once connected, you can ask your AI assistant questions like:
+- **OAuth 2.1 with PKCE.** You sign in to FoundRole through a standard authorization flow — short-lived tokens, instant revocation, no credentials shared with the AI client.
+- **HTTPS only**, with dynamic client registration and redirect-URI validation.
+- **Streamable HTTP** transport (direct), or **stdio** via this proxy.
 
-- _"Find software engineering jobs in San Francisco"_
-- _"Search for data scientist positions in California"_
-- _"Show me React developer jobs in Seattle, then search Austin next so I can compare opportunities"_
-- _"I want to work at Netflix or Uber. Search for their open developer positions"_
-- _"Find Python Django jobs in San Francisco, then show me more results if available"_
-- _"Search for ‘senior software engineer’ positions in Boston. Filter out any that seem too junior when you show me the results"_
-- _"Look for full-stack developer jobs in Denver. Show me several pages of results, then get detailed info on any that mention good benefits"_
-- _"Find ‘fintech developer’ or ‘financial software’ jobs in New York. Highlight any with higher salaries when presenting results"_
+## Troubleshooting
 
-## ❓ Troubleshooting
+**Asked to sign in / "needs authentication":**
 
-### Common Issues
+- Expected on first connect — complete the FoundRole OAuth sign-in in the browser window your client opens.
+- If tools don't appear afterward, reconnect the connector so the authorization is re-sent.
 
-**"Connection failed" error:**
+**"Connection failed":**
 
-- Check your internet connection
-- Try the setup process again
-- Ensure you have the required subscription (Claude Pro, ChatGPT Plus, etc.)
+- Check your internet connection and that the URL is exactly `https://www.foundrole.com/mcp`.
+- Confirm your client supports remote HTTP MCP; if not, use the stdio bridge (Option 2).
 
-**"Command not found" error (for stdio clients):**
+**"Command not found" (stdio clients):**
 
-- Make sure you have Node.js installed (version 22.17.0 or higher)
-- Try: `npm install -g @foundrole/ai-job-search-mcp` then `ai-job-search-mcp`
+- Install Node.js (see `engines` in `package.json` for the required version), then retry, or install globally: `npm install -g @foundrole/ai-job-search-mcp` and run `ai-job-search-mcp`.
 
-**MCP connector not working:**
+**Connector not working:**
 
-- Double-check your configuration and URL
-- Restart your AI client completely
-- Verify you have the required premium subscription
+- Double-check the URL, restart the AI client, and reconnect to re-trigger the FoundRole sign-in.
 
-### Getting Help
+## Help
 
-- 🐛 **Report issues:** [GitHub Issues](https://github.com/foundrole/jobs-mcp-proxy/issues)
-- 💬 **Questions:** Contact us at dev@foundrole.com
-- 📖 **Documentation:** [FoundRole.com](https://foundrole.com)
-
-## 🚀 What's Next?
-
-Once you have job search working in your AI assistant:
-
-1. **Refine your searches** - Be specific about roles, locations, and requirements
-2. **Save interesting opportunities** - Ask your AI to help organize and track applications
-3. **Get application help** - Use your AI to tailor resumes and cover letters
-4. **Interview preparation** - Practice with AI-generated questions based on job descriptions
+- 🌐 Website: [www.foundrole.com](https://www.foundrole.com) — free AI job search, application tracker, and company research
+- 📖 Setup guide & FAQ: [foundrole.com/ai-search-mcp](https://www.foundrole.com/ai-search-mcp)
+- 🐛 Issues: [GitHub Issues](https://github.com/foundrole/jobs-mcp-proxy/issues)
+- 💬 Questions: dev@foundrole.com
 
 ---
 
-**Happy job hunting!** 🎉
+**No account yet?** [Sign up free at FoundRole](https://www.foundrole.com), connect it once, and let your AI run the job search.
 
-_Made with ❤️ by the [FoundRole](https://foundrole.com) team_
+_Made by the [FoundRole](https://www.foundrole.com) team._

--- a/package.json
+++ b/package.json
@@ -1,16 +1,29 @@
 {
   "name": "@foundrole/ai-job-search-mcp",
   "version": "1.1.3",
-  "description": "Easy-to-use MCP proxy server that connects AI assistants like Claude to job search services. Simply run with npx for instant job search capabilities in your AI conversations.",
+  "description": "Run your job search from your AI assistant. Connect FoundRole to Claude, ChatGPT, Cursor, and any MCP client to search live jobs, track applications on a Kanban board, set follow-up reminders, and subscribe to alerts — all through conversation. OAuth 2.1, free, no API key.",
   "keywords": [
     "mcp",
+    "mcp-server",
+    "model-context-protocol",
     "proxy",
     "jobs",
     "job-search",
+    "job-board",
+    "application-tracker",
+    "job-tracker",
+    "job-alerts",
+    "career",
     "ai-assistant",
     "claude",
-    "foundrole",
-    "career"
+    "chatgpt",
+    "cursor",
+    "windsurf",
+    "lm-studio",
+    "perplexity",
+    "vscode",
+    "oauth",
+    "foundrole"
   ],
   "homepage": "https://github.com/foundrole/jobs-mcp-proxy#readme",
   "bugs": {
@@ -47,7 +60,8 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "version": "node scripts/sync-server-json.js && git add server.json"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/sync-server-json.js
+++ b/scripts/sync-server-json.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Keep server.json in sync with package.json's version.
+ *
+ * The MCP Registry validates that server.json's top-level `version` and each
+ * `packages[].version` match the npm package version it points at — a mismatch
+ * makes `mcp-publisher publish` reject the manifest. This script copies the
+ * version from package.json into server.json so the two never drift.
+ *
+ * Wired into the npm `version` lifecycle hook (see package.json): `npm version`
+ * bumps package.json, then runs this, then `git add`s server.json so it lands
+ * in the same version commit/tag the publish workflow triggers on.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8"));
+const { version } = pkg;
+
+if (!/^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version)) {
+  console.error(`Invalid version in package.json: ${version}`);
+  process.exit(1);
+}
+
+const serverPath = join(rootDir, "server.json");
+const server = JSON.parse(readFileSync(serverPath, "utf8"));
+
+server.version = version;
+if (Array.isArray(server.packages)) {
+  for (const entry of server.packages) {
+    entry.version = version;
+  }
+}
+
+writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`);
+console.log(`Synced server.json to ${version}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "author": {
+    "name": "FoundRole",
+    "url": "https://www.foundrole.com"
+  },
+  "description": "Run your job search from your AI assistant: search live jobs, track applications on a Kanban board, set follow-up reminders, and subscribe to alerts — all through conversation. OAuth 2.1, free, no API key.",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "jobs",
+    "job-search",
+    "job-board",
+    "application-tracker",
+    "job-tracker",
+    "job-alerts",
+    "career",
+    "ai-assistant",
+    "claude",
+    "chatgpt",
+    "cursor",
+    "windsurf",
+    "lm-studio",
+    "perplexity",
+    "oauth"
+  ],
+  "license": "ISC",
+  "name": "io.github.foundrole/jobs-mcp-proxy",
+  "packages": [
+    {
+      "identifier": "@foundrole/ai-job-search-mcp",
+      "registryType": "npm",
+      "transport": {
+        "type": "stdio"
+      },
+      "version": "1.1.3"
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.foundrole.com/mcp"
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/foundrole/jobs-mcp-proxy"
+  },
+  "title": "FoundRole — AI Job Search, Tracker & Reminders",
+  "version": "1.1.3",
+  "websiteUrl": "https://www.foundrole.com/ai-search-mcp"
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,4 +67,7 @@ const pkg = getPackageInfo();
 export const PROXY_NAME = pkg.name;
 export const PROXY_VERSION = pkg.version;
 export const USER_AGENT = `${PROXY_NAME}/${PROXY_VERSION}`;
-export const MCP_PROTOCOL_VERSION = "2025-03-26";
+// Informational only — the @modelcontextprotocol/sdk Client/Server negotiate
+// the actual protocol version on connect. Kept current with what the FoundRole
+// server (jobs-back) supports: 2025-11-25, 2025-06-18, 2025-03-26.
+export const MCP_PROTOCOL_VERSION = "2025-06-18";


### PR DESCRIPTION
## What & why

Brings the proxy and its public-facing surface up to date and adds official MCP Registry publishing. The repo exists to promote FoundRole; this makes the listing accurate and discoverable.

### README
- Rewritten around value/pain and the **OAuth connect flow**. Drops the inaccurate "works without sign-in / no auth" framing — the server requires OAuth at `initialize` (no tools are listed until authenticated).
- Covers the full toolkit in plain language: live job search, Kanban application tracker, reminders (email + .ics), and job alerts. **No tool counts.**
- Adds deep links to foundrole.com (jobs, job-tracker, companies, sectors, locations, and the /ai-search-mcp guide) — all verified live.

### Registry
- `server.json` — official MCP Registry manifest (schema 2025-12-11), hybrid: `remotes` (streamable-http → www.foundrole.com/mcp) + npm `packages` (stdio). Namespace `io.github.foundrole/jobs-mcp-proxy`.
- `.github/workflows/publish-mcp.yml` — publishes to the registry on a version tag via `mcp-publisher` (github-oidc, no secrets).
- `scripts/sync-server-json.js` + npm `version` hook — keep server.json version in lockstep with the npm package (the registry rejects a mismatch).
- `.gitignore` — ignore `.mcpregistry*` tokens.

### package.json
- Value-first description; keywords broadened for registry/aggregator discovery.

### src/constants.ts
- Bump informational protocol pin to 2025-06-18 (the SDK negotiates the real version; the constant is not used in the handshake).

## Release flow after merge
```
npm version <patch|minor>   # bumps package.json, syncs+stages server.json, commits+tags
npm run publish:npm         # publish to npm first (registry requires the package to exist)
git push --follow-tags      # tag triggers the publish-mcp workflow
```
